### PR TITLE
Top spenders mlytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.5.0",
+        "@nivo/bar": "^0.87.0",
         "@nivo/pie": "^0.87.0",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
@@ -1079,6 +1080,20 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nivo/annotations": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/annotations/-/annotations-0.87.0.tgz",
+      "integrity": "sha512-4Xk/soEmi706iOKszjX1EcGLBNIvhMifCYXOuLIFlMAXqhw1x2YS7PxickVSskdSzJCwJX4NgQ/R/9u6nxc5OA==",
+      "dependencies": {
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
     "node_modules/@nivo/arcs": {
       "version": "0.87.0",
       "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.87.0.tgz",
@@ -1094,23 +1109,44 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/arcs/node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
+    "node_modules/@nivo/axes": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/axes/-/axes-0.87.0.tgz",
+      "integrity": "sha512-zCRBfiRKJi+xOxwxH5Pxq/8+yv3fAYDl4a1F2Ssnp5gMIobwzVsdearvsm5B04e9bfy3ZXTL7KgbkEkSAwu6SA==",
+      "dependencies": {
+        "@nivo/core": "0.87.0",
+        "@nivo/scales": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-format": "^1.4.1",
+        "@types/d3-time-format": "^2.3.1",
+        "d3-format": "^1.4.4",
+        "d3-time-format": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/arcs/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+    "node_modules/@nivo/bar": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/bar/-/bar-0.87.0.tgz",
+      "integrity": "sha512-r/MEVCNAHKfmsy1Fb+JztVczOhIEtAx4VFs2XUbn9YpEDgxydavUJyfoy5/nGq6h5jG1/t47cfB4nZle7c0fyQ==",
       "dependencies": {
-        "d3-path": "^3.1.0"
+        "@nivo/annotations": "0.87.0",
+        "@nivo/axes": "0.87.0",
+        "@nivo/colors": "0.87.0",
+        "@nivo/core": "0.87.0",
+        "@nivo/legends": "0.87.0",
+        "@nivo/scales": "0.87.0",
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-shape": "^3.1.6",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.2.0",
+        "lodash": "^4.17.21"
       },
-      "engines": {
-        "node": ">=12"
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
       }
     },
     "node_modules/@nivo/colors": {
@@ -1133,36 +1169,10 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/colors/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@nivo/colors/node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/colors/node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
       "engines": {
         "node": ">=12"
       }
@@ -1174,17 +1184,6 @@
       "dependencies": {
         "d3-color": "1 - 3",
         "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/colors/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dependencies": {
-        "d3-array": "2 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -1216,17 +1215,6 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/core/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@nivo/core/node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -1246,29 +1234,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@nivo/core/node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@nivo/core/node_modules/d3-scale-chromatic": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
@@ -1279,36 +1244,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/d3-scale/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/core/node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-      "dependencies": {
-        "d3-time": "1 - 2"
       }
     },
     "node_modules/@nivo/legends": {
@@ -1323,43 +1258,6 @@
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/legends/node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/legends/node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@nivo/legends/node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@nivo/pie": {
@@ -1379,24 +1277,29 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/pie/node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "engines": {
-        "node": ">=12"
+    "node_modules/@nivo/scales": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/scales/-/scales-0.87.0.tgz",
+      "integrity": "sha512-IHdY9w2em/xpWurcbhUR3cUA1dgbY06rU8gmA/skFCwf3C4Da3Rqwr0XqvxmkDC+EdT/iFljMbLst7VYiCnSdw==",
+      "dependencies": {
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-time": "^1.1.1",
+        "@types/d3-time-format": "^3.0.0",
+        "d3-scale": "^4.0.2",
+        "d3-time": "^1.0.11",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21"
       }
     },
-    "node_modules/@nivo/pie/node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
+    "node_modules/@nivo/scales/node_modules/@types/d3-time": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.4.tgz",
+      "integrity": "sha512-JIvy2HjRInE+TXOmIGN5LCmeO0hkFZx5f9FZ7kiN+D+YTcc8pptsiLiuHsvwxwC7VVKmJ2ExHUgNlAiV7vQM9g=="
+    },
+    "node_modules/@nivo/scales/node_modules/@types/d3-time-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-3.0.4.tgz",
+      "integrity": "sha512-or9DiDnYI1h38J9hxKEsw513+KVuFbEVhl7qdxcaudoiqWWepapUen+2vAriFGexr6W5+P4l9+HJrB39GG+oRg=="
     },
     "node_modules/@nivo/tooltip": {
       "version": "0.87.0",
@@ -2459,6 +2362,11 @@
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
     },
+    "node_modules/@types/d3-format": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-1.4.5.tgz",
+      "integrity": "sha512-mLxrC1MSWupOSncXN/HOlWUAAIffAEBaI4+PKy2uMPsKe4FNZlk7qrbTjmzJXITQQqBHivaks4Td18azgqnotA=="
+    },
     "node_modules/@types/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.0.tgz",
@@ -2489,6 +2397,11 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
       "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-2.3.4.tgz",
+      "integrity": "sha512-xdDXbpVO74EvadI3UDxjxTdR6QIxm1FKzEA/+F8tL4GWWUg/hgvBqf6chql64U5A9ZUGWo7pEu4eNlyLwbKdhg=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -3165,6 +3078,17 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
@@ -3183,17 +3107,62 @@
         "d3-color": "1"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale/node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-time": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA=="
     },
     "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
       "dependencies": {
-        "d3-time": "1"
+        "d3-time": "1 - 2"
       }
     },
     "node_modules/date-fns": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.5.0",
+    "@nivo/bar": "^0.87.0",
     "@nivo/pie": "^0.87.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/src/components/analytics/BarChart.tsx
+++ b/src/components/analytics/BarChart.tsx
@@ -1,0 +1,58 @@
+import { Bar } from "@nivo/bar";
+import AutoSizer from "react-virtualized-auto-sizer";
+
+interface BarChartProps {
+  data: any;
+  indexBy: string;
+  keys: string[];
+  colors: string[];
+}
+
+export const BarChart = ({ data, indexBy, keys, colors }: BarChartProps) => (
+  <AutoSizer>
+    {({ width, height }) => (
+      <Bar
+        data={data}
+        width={width}
+        height={height}
+        indexBy={indexBy}
+        keys={keys}
+        margin={{ top: 50, right: 130, bottom: 50, left: 60 }}
+        padding={0.3}
+        valueScale={{ type: "linear" }}
+        indexScale={{ type: "band", round: true }}
+        colors={({ index }) => colors[index % colors.length]}
+        axisTop={null}
+        axisRight={null}
+        axisBottom={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 0,
+          legend: "User's Name",
+          legendPosition: "middle",
+          legendOffset: 32,
+          truncateTickAt: 0,
+        }}
+        axisLeft={{
+          tickSize: 5,
+          tickPadding: 5,
+          tickRotation: 0,
+          legend: "Spending ($)",
+          legendPosition: "middle",
+          legendOffset: -40,
+          truncateTickAt: 0,
+        }}
+        labelSkipWidth={12}
+        labelSkipHeight={12}
+        labelTextColor={{
+          from: "color",
+          modifiers: [["darker", 1.6]],
+        }}
+        role="application"
+        barAriaLabel={(e) =>
+          e.id + ": " + e.formattedValue + " in country: " + e.indexValue
+        }
+      />
+    )}
+  </AutoSizer>
+);

--- a/src/routes/analytics.tsx
+++ b/src/routes/analytics.tsx
@@ -66,11 +66,14 @@ export const Analytics = () => {
 
   return (
     <DefaultLayout>
+      <h1 className="text-3xl font-bold">Analytics</h1>
       <div className="h-full grid grid-cols-2 grap-4">
         <div>
+          <h2 className="text-xl font-bold">Purchase Categories:</h2>
           <PieChart data={purchaseCategoriesData} />
         </div>
         <div>
+          <h2 className="text-xl font-bold">Spending amount:</h2>
           <BarChart
             colors={colors}
             data={topSpendersLeaderboardData}
@@ -79,6 +82,7 @@ export const Analytics = () => {
           />
         </div>
         <div>
+          <h2 className="text-xl font-bold">Spending frequency:</h2>
           <BarChart
             colors={colors}
             data={numPurchasesLeaderboardData}

--- a/src/routes/analytics.tsx
+++ b/src/routes/analytics.tsx
@@ -2,39 +2,89 @@ import DefaultLayout from "@/components/layout/default-layout";
 import { PieChart } from "@/components/analytics/PieChart";
 import { apiService } from "@/utils/api";
 import { useEffect, useState } from "react";
-import { CategoryCount } from "@/types/PurchaseCategoryCount";
+import { CategoryCount, TopSpender } from "@/types/AnalyticTypes";
+import { BarChart } from "@/components/analytics/BarChart";
+import { centsToDollars } from "@/utils/currencyConverter";
 
 export const Analytics = () => {
-  const [data, setData] = useState([]);
-  const [graphData, setGraphData] = useState([{}]);
+  const [purchaseCategoriesData, setPurchaseCategoriesData] = useState([{}]);
+  const [topSpendersLeaderboardData, setTopSpendersLeaderboardData] = useState([
+    {},
+  ]);
+  const [numPurchasesLeaderboardData, setNumPurchasesLeaderboardData] =
+    useState([{}]);
+  const colors = ["#f47560", "#f1e15b", "#e8a838", "#60cdbb", "#e8c0a0"];
+
   useEffect(() => {
     apiService
       // TODO: make the group ID dynamic
       .get(`/api/analytics/purchase-categories?group_id=1`)
       .then((response) => {
-        setData(response.data);
-        const new_graph_data = construct_graph_data(response.data);
-        setGraphData(new_graph_data);
+        const new_graph_data = construct_purchase_categories_graph_data(
+          response.data
+        );
+        setPurchaseCategoriesData(new_graph_data);
+      });
+
+    apiService
+      .get(`/api/analytics/top-spenders?group_id=1`)
+      .then((response) => {
+        const { newtopSpendersLeaderboardData, newNumPurchasesData } =
+          construct_top_spenders_graph_data(response.data);
+        setTopSpendersLeaderboardData(newtopSpendersLeaderboardData);
+        setNumPurchasesLeaderboardData(newNumPurchasesData);
       });
   }, []);
 
-  const construct_graph_data = (data: CategoryCount[]) => {
-    const newGraphData = [];
+  const construct_purchase_categories_graph_data = (data: CategoryCount[]) => {
+    const newpurchaseCategoriesData = [];
     for (const entry of data) {
-      newGraphData.push({
+      newpurchaseCategoriesData.push({
         id: entry.category,
         label: entry.category,
         value: entry.count,
       });
     }
-    return newGraphData;
+    return newpurchaseCategoriesData;
+  };
+
+  const construct_top_spenders_graph_data = (data: TopSpender[]) => {
+    const newtopSpendersLeaderboardData = [];
+    const newNumPurchasesData = [];
+    for (const entry of data) {
+      newtopSpendersLeaderboardData.push({
+        name: `${entry.first_name} ${entry.last_name}`,
+        "Total Spent": centsToDollars(entry.total_spend),
+      });
+      newNumPurchasesData.push({
+        name: `${entry.first_name} ${entry.last_name}`,
+        "Number of Purchases": entry.num_purchases,
+      });
+    }
+    return { newtopSpendersLeaderboardData, newNumPurchasesData };
   };
 
   return (
     <DefaultLayout>
       <div className="h-full grid grid-cols-2 grap-4">
         <div>
-          <PieChart data={graphData} />
+          <PieChart data={purchaseCategoriesData} />
+        </div>
+        <div>
+          <BarChart
+            colors={colors}
+            data={topSpendersLeaderboardData}
+            keys={["Total Spent"]}
+            indexBy="name"
+          />
+        </div>
+        <div>
+          <BarChart
+            colors={colors}
+            data={numPurchasesLeaderboardData}
+            keys={["Number of Purchases"]}
+            indexBy="name"
+          />
         </div>
       </div>
     </DefaultLayout>

--- a/src/types/AnalyticTypes.ts
+++ b/src/types/AnalyticTypes.ts
@@ -1,0 +1,12 @@
+export interface CategoryCount {
+  category: string;
+  count: number;
+}
+
+export interface TopSpender {
+  id: number;
+  first_name: string;
+  last_name: string;
+  num_purchases: number;
+  total_spend: number;
+}

--- a/src/types/PurchaseCategoryCount.ts
+++ b/src/types/PurchaseCategoryCount.ts
@@ -1,4 +1,0 @@
-export interface CategoryCount {
-  category: string;
-  count: number;
-}

--- a/src/utils/currencyConverter.ts
+++ b/src/utils/currencyConverter.ts
@@ -1,0 +1,7 @@
+export const centsToDollars = (cents: number) => {
+  return (cents / 100).toFixed(2);
+};
+
+export const dollarsToCents = (dollars: number) => {
+  return dollars * 100;
+};


### PR DESCRIPTION
* Add nivo plots for the top spenders and top frequency spender
* Can be viewed in the /analytics route

I have put a placeholder for the group ID for now but this will be updated after the group management endpoints have been merged

<img width="1512" alt="image" src="https://github.com/CS-348-Project/Multiset-frontend/assets/60500272/283d7b1f-efd9-4f43-a9a5-d53df1775481">
